### PR TITLE
Tweak subgraph helpers to handle non IPFS.

### DIFF
--- a/hashtag-subgraph/package.json
+++ b/hashtag-subgraph/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "codegen": "graph codegen",
     "build": "graph build",
-    "deploy": "graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ blockrockettech/hashtag",
+    "deploy": "graph deploy --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ hashtag-protocol/hashtag-rinkeby",
     "create-local": "graph create --node http://localhost:8020/ hashtag-protocol/hashtag-local",
     "remove-local": "graph remove --node http://localhost:8020/ hashtag-protocol/hashtag-local",
     "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 hashtag-protocol/hashtag-local",

--- a/hashtag-subgraph/src/helpers.ts
+++ b/hashtag-subgraph/src/helpers.ts
@@ -146,23 +146,43 @@ export class NftMetadata {
  * tokenUri location of the metadata in IPFS
  */
 export function extractNftIPFSMetadata(tokenUri: string): NftMetadata | null {
-    let ipfsParts: string[] = tokenUri.split('/');
+  let ipfsHash = getIpfsHash(tokenUri);
 
-    if (ipfsParts.length > 0) {
-        let ipfsHash: string = ipfsParts[ipfsParts.length - 1];
-        let data = ipfs.cat('/ipfs/' + ipfsHash);
+  if (ipfsHash != null) {
 
-        if (data !== null) {
-            let jsonData: JSONValue = json.fromBytes(data as Bytes);
+    //let ipfsParts: string[] = tokenUri.split('/');
 
-            let nftName = jsonData.toObject().get('name').toString();
-            let nftDescription = jsonData.toObject().get('description').toString();
-            let nftImage = jsonData.toObject().get('image').toString();
+  // if (ipfsParts.length > 0) {
+  // let ipfsHash: string = ipfsParts[ipfsParts.length - 1];
+    let data = ipfs.cat('/ipfs/' + ipfsHash);
 
-            return new NftMetadata(nftName, nftDescription, nftImage);
-        }
+    if (data !== null) {
+      let jsonData: JSONValue = json.fromBytes(data as Bytes);
+
+      let nftName = jsonData.toObject().get('name').toString();
+      let nftDescription = jsonData.toObject().get('description').toString();
+      let nftImage = jsonData.toObject().get('image').toString();
+
+      return new NftMetadata(nftName, nftDescription, nftImage);
     }
+  }
+  else {
+    let msg = '--';
+    let nftImage = 'https://icon-library.com/images/no-image-available-icon/no-image-available-icon-12.jpg';
+    return new NftMetadata(msg, msg, nftImage);
+  }
 
-    return null;
+  return null;
 }
 
+export function getIpfsHash(uri: string | null): string | null {
+  if (uri != null) {
+    let hash = uri.split('/').pop()
+
+    if (hash != null && hash.startsWith('Qm')) {
+      return hash
+    }
+  }
+
+  return null
+}

--- a/hashtag-subgraph/src/helpers.ts
+++ b/hashtag-subgraph/src/helpers.ts
@@ -149,11 +149,6 @@ export function extractNftIPFSMetadata(tokenUri: string): NftMetadata | null {
   let ipfsHash = getIpfsHash(tokenUri);
 
   if (ipfsHash != null) {
-
-    //let ipfsParts: string[] = tokenUri.split('/');
-
-  // if (ipfsParts.length > 0) {
-  // let ipfsHash: string = ipfsParts[ipfsParts.length - 1];
     let data = ipfs.cat('/ipfs/' + ipfsHash);
 
     if (data !== null) {


### PR DESCRIPTION
resolves gh-213

@zawilliams @UVAMobileDev I was able to fix the Rinkeby subgraph with this pr. So any dapp pointing to Rinkeby works now. Eg. stage environment https://app.stage-y77w3ti-nv7d6mu5vsflk.us-2.platformsh.site/

Minting and tagging should work now -- even with the opensea url experiment PR'ed here: https://github.com/hashtag-protocol/hashtag-protocol/pull/201