### PR TITLE
Switch to use runtimeConfig for Nuxt

### DIFF
--- a/hashtag-dapp/components/EthAccount.vue
+++ b/hashtag-dapp/components/EthAccount.vue
@@ -56,7 +56,7 @@ export default {
     this.ens = this.homesteadProvider
       ? await this.homesteadProvider.lookupAddress(this.value)
       : null;
-    this.addressUrl = `${process.env.etherscanBaseUrl}/address/${this.value}`;
+    this.addressUrl = `${this.$config.etherscanBaseUrl}/address/${this.value}`;
   },
 };
 </script>

--- a/hashtag-dapp/components/HashtagTokenId.vue
+++ b/hashtag-dapp/components/HashtagTokenId.vue
@@ -26,7 +26,7 @@ export default {
     };
   },
   created() {
-    this.tokenUrl = `${process.env.etherscanBaseUrl}/token/${process.env.hashtagProtocolContractAddress}?a=${this.value}`;
+    this.tokenUrl = `${this.$config.etherscanBaseUrl}/token/${this.$config.hashtagProtocolContractAddress}?a=${this.value}`;
     this.label = `View ${this.hashtag} on Etherscan`;
   },
 };

--- a/hashtag-dapp/components/Navbar.vue
+++ b/hashtag-dapp/components/Navbar.vue
@@ -119,19 +119,19 @@ export default {
       supportMenuArr: {
         docs: {
           text: "Docs",
-          path: process.env.docs,
+          path: this.$config.docs,
         },
         discord: {
           text: "Discord",
-          path: process.env.discordServer,
+          path: this.$config.discordServer,
         },
         substack: {
           text: "Substack",
-          path: process.env.substack,
+          path: this.$config.substack,
         },
         website: {
           text: "Website",
-          path: process.env.website,
+          path: this.$config.website,
         },
       },
     };

--- a/hashtag-dapp/components/TxnModalTxSent.vue
+++ b/hashtag-dapp/components/TxnModalTxSent.vue
@@ -49,7 +49,7 @@ export default {
     ]),
     ...mapGetters("wallet", ["address", "transactionState"]),
     etherscanUrl: function () {
-      return `${process.env.etherscanBaseUrl}/tx/${this.transactionState.hash}`;
+      return `${this.$config.etherscanBaseUrl}/tx/${this.transactionState.hash}`;
     },
     /**
      * Show txn complete title & animation depending on transaction type.

--- a/hashtag-dapp/nuxt.config.js
+++ b/hashtag-dapp/nuxt.config.js
@@ -61,7 +61,7 @@ export default {
     scss: ["~/assets/css/variables.scss"],
   },
 
-  env: {
+  publicRuntimeConfig: {
     website: "https://www.hashtag-protocol.org",
     app: "https://app.hashtag-protocol.org",
     docs: "https://docs.hashtag-protocol.org",
@@ -95,6 +95,7 @@ export default {
     discordServer:
       process.env.VUE_APP_DISCORD_SERVER || "https://discord.gg/EyTJFRm",
   },
+  privateRuntimeConfig: {},
 
   gtm: {
     id: "GTM-MRK383F",

--- a/hashtag-dapp/pages/hashtag/_hashtag.vue
+++ b/hashtag-dapp/pages/hashtag/_hashtag.vue
@@ -379,13 +379,13 @@ export default {
     },
     copyToClipboard() {
       const cb = navigator.clipboard;
-      const url = process.env.app + this.$route.path;
+      const url = this.$config.app + this.$route.path;
       cb.writeText(url);
     },
   },
   computed: {
     image() {
-      return process.env.imageApi + this.hashtagsByName[0].id + ".png";
+      return this.$config.imageApi + this.hashtagsByName[0].id + ".png";
     },
     randomSharingMessage() {
       const messages = [
@@ -400,7 +400,7 @@ export default {
       const encodedString = encodeURIComponent(
         `Check out the hashtag ${
           this.hashtagsByName[0].displayHashtag
-        } on @HashtagProtoHQ\n\n${process.env.app + this.$route.path}`
+        } on @HashtagProtoHQ\n\n${this.$config.app + this.$route.path}`
       );
       return "https://twitter.com/intent/tweet?text=" + encodedString;
     },
@@ -408,7 +408,7 @@ export default {
       const encodedString = encodeURIComponent(
         `Check out the hashtag ${
           this.hashtagsByName[0].displayHashtag
-        } on Hashtag Protocol\n\n${process.env.app + this.$route.path}`
+        } on Hashtag Protocol\n\n${this.$config.app + this.$route.path}`
       );
       return "https://www.facebook.com/share.php?u=" + encodedString;
     },

--- a/hashtag-dapp/store/wallet/index.js
+++ b/hashtag-dapp/store/wallet/index.js
@@ -13,8 +13,6 @@ let provider;
 let onboard = {};
 let blocknative = {};
 
-const localstorageWalletKey = process.env.localstorageWalletKey;
-
 /**
  * The Vuex 'state' object.
  * @name State
@@ -67,8 +65,8 @@ const actions = {
   async initOnboard({ dispatch, commit }) {
     // Initialize onboard.
     onboard = Onboard({
-      dappId: process.env.blocknativeApiKey,
-      networkId: process.env.onboardNetworkID,
+      dappId: this.$config.blocknativeApiKey,
+      networkId: this.$config.onboardNetworkID,
       subscriptions: {
         address: (address) => {
           commit("setWalletAddress", address);
@@ -91,8 +89,8 @@ const actions = {
 
     // Initialize blocknative SDK for mempool notifications.
     blocknative = new BlocknativeSdk({
-      dappId: process.env.blocknativeApiKey,
-      networkId: process.env.onboardNetworkID,
+      dappId: this.$config.blocknativeApiKey,
+      networkId: this.$config.onboardNetworkID,
     });
 
     dispatch("reconnectWallet");
@@ -132,7 +130,7 @@ const actions = {
         hashtagProtocolContract,
         erc721HashtagRegistryContract,
       },
-      publisher: process.env.publisherWalletAddress,
+      publisher: this.$config.publisherWalletAddress,
     });
 
     dispatch("getTaggingFee");
@@ -146,7 +144,7 @@ const actions = {
       const ethersProvider = new ethers.providers.Web3Provider(wallet.provider);
       provider = ethersProvider;
       // store the selected wallet name to be retrieved next time the app loads.
-      localStorage.setItem(localstorageWalletKey, wallet.name);
+      localStorage.setItem(this.$config.localstorageWalletKey, wallet.name);
     } else {
       provider = null;
       commit("setWalletName", "");
@@ -158,7 +156,7 @@ const actions = {
   // and checks the wallet.
   async reconnectWallet() {
     const previouslySelectedWallet = window.localStorage.getItem(
-      localstorageWalletKey
+      this.$config.localstorageWalletKey
     );
     if (!previouslySelectedWallet) {
       return false;
@@ -192,7 +190,7 @@ const actions = {
   },
 
   disconnectWallet({ state, commit }) {
-    localStorage.removeItem(localstorageWalletKey);
+    localStorage.removeItem(this.$config.localstorageWalletKey);
     onboard.walletReset();
     state.openModalCloseFn();
     commit("setOpenModalCloseFn", () => {});


### PR DESCRIPTION
This PR is to address #233 and #225.

I did some testing on a separate project on Platform.sh to test things out.

The problem we ran into was that once a branch was merged to master, it would not rebuild and instead would use `stage` environment variables causing the `mainnet` dApp to use `rinkeby` and Rinkeby Subgraphs.

I followed the Nuxt.js [blog post](https://nuxtjs.org/blog/moving-from-nuxtjs-dotenv-to-runtime-config) about migrating from `@nuxtjs/dotenv` to runtime config.

Once this is in place on `master` and `stage`, we should be good to go with `env` variables working the way we expect on `master` and `stage` and child PRs.