### PR TITLE
Update references to Etherscan to Polygonscan

### DIFF
--- a/hashtag-dapp/components/EthAccount.vue
+++ b/hashtag-dapp/components/EthAccount.vue
@@ -21,12 +21,7 @@
       </span>
     </b-tooltip>
     &nbsp;&nbsp;
-    <b-tooltip
-      label="view on Etherscan"
-      position="is-bottom"
-      type="is-dark"
-      size="is-small"
-    >
+    <b-tooltip :label="`View on ${explorerName}`" position="is-bottom" type="is-dark" size="is-small">
       <a :href="this.addressUrl" target="_blank">
         <b-icon icon="ethereum" type="is-grey-light" size="is-small"> </b-icon>
       </a>
@@ -44,7 +39,7 @@ export default {
     route: String,
   },
   computed: {
-    ...mapGetters("wallet", ["homesteadProvider"]),
+    ...mapGetters("wallet", ["homesteadProvider", "explorerName"]),
   },
   data() {
     return {
@@ -53,9 +48,7 @@ export default {
     };
   },
   async mounted() {
-    this.ens = this.homesteadProvider
-      ? await this.homesteadProvider.lookupAddress(this.value)
-      : null;
+    this.ens = this.homesteadProvider ? await this.homesteadProvider.lookupAddress(this.value) : null;
     this.addressUrl = `${this.$config.etherscanBaseUrl}/address/${this.value}`;
   },
 };

--- a/hashtag-dapp/components/HashtagTokenId.vue
+++ b/hashtag-dapp/components/HashtagTokenId.vue
@@ -1,13 +1,7 @@
 <template>
   <div>
     {{ value }}
-    <b-tooltip
-      :label="this.label"
-      position="is-bottom"
-      type="is-dark"
-      size="is-small"
-      :animated="true"
-    >
+    <b-tooltip :label="this.label" position="is-bottom" type="is-dark" size="is-small" :animated="true">
       <a :href="this.tokenUrl" target="_blank">
         <b-icon icon="ethereum" type="is-grey-light" size="is-small"> </b-icon>
       </a>
@@ -16,6 +10,8 @@
 </template>
 
 <script>
+import { mapGetters } from "vuex";
+
 export default {
   name: "HashtagTokenId",
   props: ["value", "hashtag"],
@@ -25,9 +21,12 @@ export default {
       label: "",
     };
   },
+  computed: {
+    ...mapGetters("wallet", ["explorerName"]),
+  },
   created() {
     this.tokenUrl = `${this.$config.etherscanBaseUrl}/token/${this.$config.hashtagProtocolContractAddress}?a=${this.value}`;
-    this.label = `View ${this.hashtag} on Etherscan`;
+    this.label = `View ${this.hashtag} on ${this.explorerName}`;
   },
 };
 </script>

--- a/hashtag-dapp/components/PseudoOwners.vue
+++ b/hashtag-dapp/components/PseudoOwners.vue
@@ -34,7 +34,7 @@
                     ><a class=""><span>0x477c...d4ef</span></a></span
                   ></span
                 >
-                <span data-label="view on Etherscan" class="is-dark is-bottom is-small b-tooltip"
+                <span :data-label="`View on ${explorerName}`" class="is-dark is-bottom is-small b-tooltip"
                   ><a
                     ><span class="icon has-text-grey-light is-small"><i class="mdi mdi-ethereum"></i></span></a></span
               ></span>
@@ -60,7 +60,7 @@
                     ><a><span>0x07bd...5b0e</span></a></span
                   ></span
                 >
-                <span data-label="view on Etherscan" class="is-dark is-bottom is-small b-tooltip"
+                <span :data-label="`View on ${explorerName}`" class="is-dark is-bottom is-small b-tooltip"
                   ><a
                     ><span class="icon has-text-grey-light is-small"><i class="mdi mdi-ethereum"></i></span></a></span
               ></span>
@@ -86,7 +86,7 @@
                     ><a class=""><span>0xd677...bc4b</span></a></span
                   ></span
                 >
-                <span data-label="view on Etherscan" class="is-dark is-bottom is-small b-tooltip"
+                <span :data-label="`View on ${explorerName}`" class="is-dark is-bottom is-small b-tooltip"
                   ><a
                     ><span class="icon has-text-grey-light is-small"><i class="mdi mdi-ethereum"></i></span></a></span
               ></span>
@@ -112,7 +112,7 @@
                     ><a><span>0x12d0...e4c2</span></a></span
                   ></span
                 >
-                <span data-label="view on Etherscan" class="is-dark is-bottom is-small b-tooltip"
+                <span :data-label="`View on ${explorerName}`" class="is-dark is-bottom is-small b-tooltip"
                   ><a
                     ><span class="icon has-text-grey-light is-small"><i class="mdi mdi-ethereum"></i></span></a></span
               ></span>
@@ -148,7 +148,7 @@ import { mapGetters } from "vuex";
 
 export default {
   computed: {
-    ...mapGetters("wallet", ["currencyName"]),
+    ...mapGetters("wallet", ["currencyName", "explorerName"]),
   },
 };
 </script>

--- a/hashtag-dapp/components/TxnModalTxSent.vue
+++ b/hashtag-dapp/components/TxnModalTxSent.vue
@@ -8,10 +8,9 @@
         </div>
         <p class="title has-text-weight-semibold">{{ title }}</p>
         <p class="mb-6">
-          When complete, this screen will update or you may close this window
-          and receive updates in the main site.
+          When complete, this screen will update or you may close this window and receive updates in the main site.
         </p>
-        <a :href="etherscanUrl" target="_blank">view on Etherscan</a>
+        <a :href="etherscanUrl" target="_blank">View on {{ explorerName }}</a>
       </div>
     </section>
     <footer class="modal-card-foot">
@@ -42,12 +41,8 @@ export default {
     LottieAnimation,
   },
   computed: {
-    ...mapGetters("protocolAction", [
-      "protocolAction",
-      "newHashtag",
-      "targetNft",
-    ]),
-    ...mapGetters("wallet", ["address", "transactionState"]),
+    ...mapGetters("protocolAction", ["protocolAction", "newHashtag", "targetNft"]),
+    ...mapGetters("wallet", ["address", "transactionState", "explorerName"]),
     etherscanUrl: function () {
       return `${this.$config.etherscanBaseUrl}/tx/${this.transactionState.hash}`;
     },
@@ -58,9 +53,7 @@ export default {
       return protocolActionMap[this.protocolAction].txnSentMsg;
     },
     animation: function () {
-      return `./animations/${
-        protocolActionMap[this.protocolAction].animationFile
-      }`;
+      return `./animations/${protocolActionMap[this.protocolAction].animationFile}`;
     },
   },
 };

--- a/hashtag-dapp/components/WalletInfo.vue
+++ b/hashtag-dapp/components/WalletInfo.vue
@@ -19,7 +19,7 @@
         <div class="level-item has-text-centered">
           <div>
             <p class="heading">Network</p>
-            <p class="subtitle" v-if="networkInfo">{{ networkInfo.Name }}</p>
+            <p class="subtitle" v-if="networkInfo">{{ networkInfo.name }}</p>
           </div>
         </div>
         <div class="level-item has-text-centered">

--- a/hashtag-dapp/components/WalletInfo.vue
+++ b/hashtag-dapp/components/WalletInfo.vue
@@ -38,7 +38,7 @@
         <div class="level-item has-text-centered">
           <a :href="this.addressUrl" target="_blank">
             <b-icon icon="ethereum" size="is-small"> </b-icon>
-            View on Etherscan
+            View on {{ explorerName }}
           </a>
         </div>
         <div class="level-item has-text-centered">
@@ -62,7 +62,7 @@ export default {
     };
   },
   computed: {
-    ...mapGetters("wallet", ["address", "balance", "name", "networkId", "networkInfo", "currencyName"]),
+    ...mapGetters("wallet", ["address", "balance", "name", "networkId", "networkInfo", "currencyName", "explorerName"]),
   },
   methods: {
     disconnectWallet() {

--- a/hashtag-dapp/data/onBoardChainMap.json
+++ b/hashtag-dapp/data/onBoardChainMap.json
@@ -11,6 +11,10 @@
     "name": "Ganache Localdev",
     "url": "https://rinkeby.etherscan.io"
   },
+  "137": {
+    "name": "Polygon Mainnet",
+    "url": "https://polygonscan.com"
+  },
   "80001": {
     "name": "Polygon Mumbai",
     "url": "https://mumbai.polygonscan.com"

--- a/hashtag-dapp/data/onBoardChainMap.json
+++ b/hashtag-dapp/data/onBoardChainMap.json
@@ -1,22 +1,22 @@
 {
   "1": {
-    "Name": "Mainnet",
+    "name": "Mainnet",
     "url": "https://etherscan.io"
   },
   "4": {
-    "Name": "Rinkeby",
+    "name": "Rinkeby",
     "url": "https://rinkeby.etherscan.io"
   },
   "5777": {
-    "Name": "Ganache Localdev",
+    "name": "Ganache Localdev",
     "url": "https://rinkeby.etherscan.io"
   },
   "80001": {
-    "Name": "Polygon Mumbai",
     "url": "https://mumbai.polygonscan.com/"
+    "name": "Polygon Mumbai",
   },
   "31337": {
-    "Name": "Hardhat Localdev",
+    "name": "Hardhat Localdev",
     "url": "https://rinkeby.etherscan.io"
   }
 }

--- a/hashtag-dapp/data/onBoardChainMap.json
+++ b/hashtag-dapp/data/onBoardChainMap.json
@@ -12,8 +12,8 @@
     "url": "https://rinkeby.etherscan.io"
   },
   "80001": {
-    "url": "https://mumbai.polygonscan.com/"
     "name": "Polygon Mumbai",
+    "url": "https://mumbai.polygonscan.com"
   },
   "31337": {
     "name": "Hardhat Localdev",

--- a/hashtag-dapp/store/wallet/index.js
+++ b/hashtag-dapp/store/wallet/index.js
@@ -60,7 +60,7 @@ const getters = {
     return onBoardChainMap[state.networkId];
   },
   explorerName: (state) => {
-    return state.networkId === 137 || state.networkId === 80001 ? "PolyScan" : "Etherscan";
+    return state.networkId === 137 || state.networkId === 80001 ? "PolygonScan" : "Etherscan";
   },
   balance: (state) => state.balance,
   name: (state) => state.name,

--- a/hashtag-dapp/store/wallet/index.js
+++ b/hashtag-dapp/store/wallet/index.js
@@ -59,12 +59,19 @@ const getters = {
   networkInfo: (state) => {
     return onBoardChainMap[state.networkId];
   },
+  explorerName: (state) => {
+    return state.networkId === 137 || state.networkId === 80001 ? "PolyScan" : "Etherscan";
+  },
   balance: (state) => state.balance,
   name: (state) => state.name,
   transactionState: (state) => state.transactionState,
 };
 
 const actions = {
+  nuxtServerInit({ commit }, { $config }) {
+    commit("setWalletNetworkId", $config.onboardNetworkID);
+  },
+
   async initOnboard({ dispatch, commit }) {
     // Initialize onboard.
     onboard = Onboard({

--- a/hashtag-dapp/store/wallet/index.js
+++ b/hashtag-dapp/store/wallet/index.js
@@ -53,14 +53,16 @@ const getters = {
   accrued: (state) => state.accrued,
   address: (state) => state.address,
   networkId: (state) => state.networkId,
-  currencyName: (state) => {
-    return state.networkId === 137 || state.networkId === 80001 ? "MATIC" : "ETH";
-  },
   networkInfo: (state) => {
     return onBoardChainMap[state.networkId];
   },
+  // The following two probably could use a better home
+  // as the dapp will be running on polygon for the forseeable future.
+  currencyName: (state) => {
+    return "MATIC";
+  },
   explorerName: (state) => {
-    return state.networkId === 137 || state.networkId === 80001 ? "PolygonScan" : "Etherscan";
+    return "PolygonScan";
   },
   balance: (state) => state.balance,
   name: (state) => state.name,

--- a/hashtag-dapp/store/wallet/index.js
+++ b/hashtag-dapp/store/wallet/index.js
@@ -44,8 +44,9 @@ const state = () => ({
   },
   accrued: 0,
   openModalCloseFn: () => {},
-
   transactionState: {},
+  currencyName: "MATIC",
+  explorerName: "PolygonScan",
 });
 
 const getters = {
@@ -58,12 +59,8 @@ const getters = {
   },
   // The following two probably could use a better home
   // as the dapp will be running on polygon for the forseeable future.
-  currencyName: (state) => {
-    return "MATIC";
-  },
-  explorerName: (state) => {
-    return "PolygonScan";
-  },
+  currencyName: (state) => state.currencyName,
+  explorerName: (state) => state.explorerName,
   balance: (state) => state.balance,
   name: (state) => state.name,
   transactionState: (state) => state.transactionState,


### PR DESCRIPTION
Addresses #272.

Pretty self-explanatory, but didn't change anything with the URL references since that is set via Nuxt config. Updated the wording (i.e. "Etherscan" vs "PolygonScan" to be pulled from the wallet store in template references.