### PR TITLE
Refactor hashtag search/mint on home page

### DIFF
--- a/hashtag-dapp/apollo/queries.js
+++ b/hashtag-dapp/apollo/queries.js
@@ -461,6 +461,22 @@ export const FIRST_THOUSAND_HASHTAGS = gql(`
   }
 `);
 
+export const HASHTAGS_SEARCH = gql(`
+  query hashtagsSearch($name: String!) {
+    hashtagsSearch: hashtags(first: 10, where: { hashtagWithoutHash_contains: $name }) {
+      id
+      name
+      displayHashtag
+      hashtagWithoutHash
+      owner
+      creator
+      publisher
+      timestamp
+      tagCount
+    }
+  }
+`);
+
 export const NFTS_ASSETS_NAME_CONTAINS = gql(`
   query nameContains($first: Int!, $name: String!) {
     nameContains: tokens(first: $first, where: {metadataName_contains: $name}) {

--- a/hashtag-dapp/apollo/queries.js
+++ b/hashtag-dapp/apollo/queries.js
@@ -57,7 +57,7 @@ export const SNAPSHOT = gql(`
         creators(first: 10, orderBy: tagCount, orderDirection: desc) {
             id
             mintCount
-            tagCount 
+            tagCount
             tagFees
         }
     }
@@ -133,7 +133,7 @@ export const TAGS_BY_DIGITAL_ASSET = gql(`
     publisher
     hashtagId
     hashtagDisplayHashtag
-    
+
   }
 }`);
 
@@ -304,7 +304,7 @@ query tagsByPublisher($publisher: String!, $first: Int!, $skip: Int!) {
 export const TAGGER_BY_ACC = gql(`
 query taggerByAcc($id: String!) {
     taggerByAcc: tagger(id: $id){
-        id  
+        id
         tagCount
         feesPaid
     }
@@ -314,7 +314,7 @@ query taggerByAcc($id: String!) {
 export const PUBLISHER_BY_ACC = gql(`
 query publisherByAcc($id: String!) {
     publisherByAcc: publisher(id: $id){
-      id  
+      id
       mintCount
       tagCount
       tagFees
@@ -370,7 +370,7 @@ query pagedTags($first: Int!, $skip: Int!) {
             timestamp
             publisher
         }
-   }     
+   }
 `);
 
 export const ALL_PUBLISHERS = gql`

--- a/hashtag-dapp/components/HashtagSearch.vue
+++ b/hashtag-dapp/components/HashtagSearch.vue
@@ -23,12 +23,8 @@
           >
             <template slot-scope="props">
               <b-taglist attached>
-                <b-tag type="is-primary" size="is-medium"
-                  >{{ props.option.displayHashtag }}
-                </b-tag>
-                <b-tag type="is-dark" size="is-medium"
-                  >{{ props.option.tagCount }}
-                </b-tag>
+                <b-tag type="is-primary" size="is-medium">{{ props.option.displayHashtag }} </b-tag>
+                <b-tag type="is-dark" size="is-medium">{{ props.option.tagCount }} </b-tag>
               </b-taglist>
             </template>
             <template slot="empty">
@@ -132,9 +128,7 @@ export default {
     },
   },
   created() {
-    this.hashtagValidationService = new HashtagValidationService(
-      this.$buefy.toast
-    );
+    this.hashtagValidationService = new HashtagValidationService(this.$buefy.toast);
   },
 };
 </script>

--- a/hashtag-dapp/components/HashtagSearch.vue
+++ b/hashtag-dapp/components/HashtagSearch.vue
@@ -28,9 +28,7 @@
               </b-taglist>
             </template>
             <template slot="empty">
-              <span class="new-hashtag"
-                >Unique HASHTAG! Press enter to continue...</span
-              >
+              <span class="new-hashtag">Unique HASHTAG! Press enter to mint it...</span>
             </template>
           </b-taginput>
         </b-field>

--- a/hashtag-dapp/components/MintingWidget.vue
+++ b/hashtag-dapp/components/MintingWidget.vue
@@ -19,6 +19,9 @@ export default {
       if (hashtag.id) {
         /* eslint-disable-next-line no-console */
         console.log("minting widget existing Hashtag", hashtag);
+        this.$router.push({
+          path: `/hashtag/${hashtag.hashtagWithoutHash}`,
+        });
       } else {
         await this.$store.dispatch("protocolAction/updateNewHashtag", hashtag);
         await this.$store.dispatch("protocolAction/updateProtocolAction", "mintHashtag");

--- a/hashtag-dapp/components/MintingWidget.vue
+++ b/hashtag-dapp/components/MintingWidget.vue
@@ -21,10 +21,7 @@ export default {
         console.log("minting widget existing Hashtag", hashtag);
       } else {
         await this.$store.dispatch("protocolAction/updateNewHashtag", hashtag);
-        await this.$store.dispatch(
-          "protocolAction/updateProtocolAction",
-          "mintHashtag"
-        );
+        await this.$store.dispatch("protocolAction/updateProtocolAction", "mintHashtag");
         await this.$store.dispatch("wallet/updateTransactionState", {
           eventCode: "mintConfirm",
         });
@@ -66,10 +63,7 @@ export default {
         if (this.validateTag(newHashtag)) {
           // This is a valid, new hashtag, update the application.
           await this.$store.dispatch("wallet/updateNewHashtag", newHashtag);
-          await this.$store.dispatch(
-            "protocolAction/updateProtocolAction",
-            "mintHashtag"
-          );
+          await this.$store.dispatch("protocolAction/updateProtocolAction", "mintHashtag");
           // Web3 txn state.
           await this.$store.dispatch("wallet/updateTransactionState", {
             eventCode: "mintConfirm",
@@ -82,10 +76,7 @@ export default {
             trapFocus: true,
           });
 
-          this.$store.dispatch(
-            "wallet/captureOpenModalCloseFn",
-            mintModal.close
-          );
+          this.$store.dispatch("wallet/captureOpenModalCloseFn", mintModal.close);
         }
       }
     },

--- a/hashtag-dapp/pages/hashtag/_hashtag.vue
+++ b/hashtag-dapp/pages/hashtag/_hashtag.vue
@@ -1,10 +1,6 @@
 <template>
   <div class="body" v-if="!loading">
-    <SocialHead
-      :title="hashtagsByName[0].displayHashtag + ' | Hashtag Protocol'"
-      :description="randomSharingMessage"
-      :image="imageUrl"
-    />
+    <SocialHead :title="displayHashtag + ' | Hashtag Protocol'" :description="randomSharingMessage" :image="imageUrl" />
     <Header />
     <section class="main" v-if="hashtagsByName && hashtagsByName[0]">
       <div class="container">
@@ -308,7 +304,7 @@ export default {
   },
   head() {
     return {
-      title: `${this.hashtagsByName[0].displayHashtag} | Hashtag Protocol`,
+      title: `${this.displayHashtag} | Hashtag Protocol`,
       meta: [
         {
           hid: "description",
@@ -432,10 +428,13 @@ export default {
   },
   computed: {
     ...mapGetters("wallet", ["currencyName"]),
+    displayHashtag() {
+      return this.hashtagsByName && this.hashtagsByName[0].displayHashtag;
+    },
     randomSharingMessage() {
       const messages = [
-        `${this.hashtagsByName[0].displayHashtag} stored as a non-fungible token (NFT) on the blockchain.`,
-        `Not your typical hashtag. This is ${this.hashtagsByName[0].displayHashtag} as an NFT.`,
+        `${this.displayHashtag} stored as a non-fungible token (NFT) on the blockchain.`,
+        `Not your typical hashtag. This is ${this.displayHashtag} as an NFT.`,
         `Hashtag Protocol enables social content tagging for the decentralized internet.`,
       ];
       const randomNumber = Math.floor(Math.random() * 3);
@@ -443,7 +442,7 @@ export default {
     },
     twitterSharingUrl() {
       const encodedString = encodeURIComponent(
-        `Check out the hashtag ${this.hashtagsByName[0].displayHashtag} on @HashtagProtoHQ\n\n${
+        `Check out the hashtag ${this.displayHashtag} on @HashtagProtoHQ\n\n${
           this.$store.state.dappBaseUrl + this.$route.path
         }`,
       );
@@ -451,7 +450,7 @@ export default {
     },
     facebookSharingUrl() {
       const encodedString = encodeURIComponent(
-        `Check out the hashtag ${this.hashtagsByName[0].displayHashtag} on Hashtag Protocol\n\n${
+        `Check out the hashtag ${this.displayHashtag} on Hashtag Protocol\n\n${
           this.$store.state.dappBaseUrl + this.$route.path
         }`,
       );

--- a/hashtag-dapp/pages/index.vue
+++ b/hashtag-dapp/pages/index.vue
@@ -40,51 +40,22 @@
                     />
                     <h2 class="title is-5">Newest hashtags</h2>
                     <template>
-                      <b-table
-                        :data="hashtags ? hashtags.slice(0, 10) : []"
-                        focusable
-                      >
+                      <b-table :data="hashtags ? hashtags.slice(0, 10) : []" focusable>
                         <template slot="footer" v-if="!isCustom">
                           <div class="has-text-right">
-                            <nuxt-link :to="{ name: 'hashtags' }"
-                              >Browse hashtags
-                            </nuxt-link>
+                            <nuxt-link :to="{ name: 'hashtags' }">Browse hashtags </nuxt-link>
                             &nbsp;
-                            <b-icon
-                              icon="arrow-right"
-                              type="is-dark"
-                              size="is-small"
-                            >
-                            </b-icon>
+                            <b-icon icon="arrow-right" type="is-dark" size="is-small"> </b-icon>
                           </div>
                         </template>
-                        <b-table-column
-                          field="name"
-                          label="Hashtag"
-                          width="40"
-                          v-slot="props"
-                        >
+                        <b-table-column field="name" label="Hashtag" width="40" v-slot="props">
                           <hashtag :value="props.row.displayHashtag"></hashtag>
                         </b-table-column>
-                        <b-table-column
-                          field="timestamp"
-                          label="Created"
-                          v-slot="props"
-                        >
-                          <TimestampFrom
-                            :value="props.row.timestamp"
-                          ></TimestampFrom>
+                        <b-table-column field="timestamp" label="Created" v-slot="props">
+                          <TimestampFrom :value="props.row.timestamp"></TimestampFrom>
                         </b-table-column>
-                        <b-table-column
-                          field="creator"
-                          label="Creator"
-                          :visible="$screen.desktop"
-                          v-slot="props"
-                        >
-                          <eth-account
-                            :value="props.row.creator"
-                            route="creator-address"
-                          ></eth-account>
+                        <b-table-column field="creator" label="Creator" :visible="$screen.desktop" v-slot="props">
+                          <eth-account :value="props.row.creator" route="creator-address"></eth-account>
                         </b-table-column>
                         <b-table-column
                           field="publisher"
@@ -92,10 +63,7 @@
                           :visible="$screen.widescreen"
                           v-slot="props"
                         >
-                          <eth-account
-                            :value="props.row.publisher"
-                            route="publisher-address"
-                          ></eth-account>
+                          <eth-account :value="props.row.publisher" route="publisher-address"></eth-account>
                         </b-table-column>
                       </b-table>
                     </template>
@@ -144,46 +112,19 @@
                               Browse creators
                             </nuxt-link>
                             &nbsp;
-                            <b-icon
-                              icon="arrow-right"
-                              type="is-dark"
-                              size="is-small"
-                            >
-                            </b-icon>
+                            <b-icon icon="arrow-right" type="is-dark" size="is-small"> </b-icon>
                           </div>
                         </template>
-                        <b-table-column
-                          field="id"
-                          label="Creator"
-                          v-slot="props"
-                        >
-                          <eth-account
-                            :value="props.row.id"
-                            route="creator-address"
-                          ></eth-account>
+                        <b-table-column field="id" label="Creator" v-slot="props">
+                          <eth-account :value="props.row.id" route="creator-address"></eth-account>
                         </b-table-column>
-                        <b-table-column
-                          field="mintedCount"
-                          label="Hashtags"
-                          centered
-                          v-slot="props"
-                        >
+                        <b-table-column field="mintedCount" label="Hashtags" centered v-slot="props">
                           {{ props.row.mintCount }}
                         </b-table-column>
-                        <b-table-column
-                          field="tagCount"
-                          label="Tag count"
-                          centered
-                          v-slot="props"
-                        >
+                        <b-table-column field="tagCount" label="Tag count" centered v-slot="props">
                           {{ props.row.tagCount }}
                         </b-table-column>
-                        <b-table-column
-                          field="revenue"
-                          label="Revenue"
-                          centered
-                          v-slot="props"
-                        >
+                        <b-table-column field="revenue" label="Revenue" centered v-slot="props">
                           <eth-amount :value="props.row.tagFees"></eth-amount>
                         </b-table-column>
                       </b-table>
@@ -212,46 +153,19 @@
                               Browse publishers
                             </nuxt-link>
                             &nbsp;
-                            <b-icon
-                              icon="arrow-right"
-                              type="is-dark"
-                              size="is-small"
-                            >
-                            </b-icon>
+                            <b-icon icon="arrow-right" type="is-dark" size="is-small"> </b-icon>
                           </div>
                         </template>
-                        <b-table-column
-                          field="id"
-                          label="Publisher"
-                          v-slot="props"
-                        >
-                          <eth-account
-                            :value="props.row.id"
-                            route="publisher-address"
-                          ></eth-account>
+                        <b-table-column field="id" label="Publisher" v-slot="props">
+                          <eth-account :value="props.row.id" route="publisher-address"></eth-account>
                         </b-table-column>
-                        <b-table-column
-                          field="mintedCount"
-                          label="Hashtags"
-                          centered
-                          v-slot="props"
-                        >
+                        <b-table-column field="mintedCount" label="Hashtags" centered v-slot="props">
                           {{ props.row.mintCount }}
                         </b-table-column>
-                        <b-table-column
-                          field="tagCount"
-                          label="Tag count"
-                          centered
-                          v-slot="props"
-                        >
+                        <b-table-column field="tagCount" label="Tag count" centered v-slot="props">
                           {{ props.row.tagCount }}
                         </b-table-column>
-                        <b-table-column
-                          field="revenue"
-                          label="Revenue"
-                          centered
-                          v-slot="props"
-                        >
+                        <b-table-column field="revenue" label="Revenue" centered v-slot="props">
                           <eth-amount :value="props.row.tagFees"></eth-amount>
                         </b-table-column>
                       </b-table>
@@ -284,30 +198,13 @@
                               Browse taggers
                             </nuxt-link>
                             &nbsp;
-                            <b-icon
-                              icon="arrow-right"
-                              type="is-dark"
-                              size="is-small"
-                            >
-                            </b-icon>
+                            <b-icon icon="arrow-right" type="is-dark" size="is-small"> </b-icon>
                           </div>
                         </template>
-                        <b-table-column
-                          field="id"
-                          label="Tagger"
-                          v-slot="props"
-                        >
-                          <eth-account
-                            :value="props.row.id"
-                            route="tagger-address"
-                          ></eth-account>
+                        <b-table-column field="id" label="Tagger" v-slot="props">
+                          <eth-account :value="props.row.id" route="tagger-address"></eth-account>
                         </b-table-column>
-                        <b-table-column
-                          field="tagCount"
-                          label="Tag count"
-                          centered
-                          v-slot="props"
-                        >
+                        <b-table-column field="tagCount" label="Tag count" centered v-slot="props">
                           {{ props.row.tagCount }}
                         </b-table-column>
                       </b-table>
@@ -336,27 +233,13 @@
                               Browse hashtags
                             </nuxt-link>
                             &nbsp;
-                            <b-icon
-                              icon="arrow-right"
-                              type="is-dark"
-                              size="is-small"
-                            >
-                            </b-icon>
+                            <b-icon icon="arrow-right" type="is-dark" size="is-small"> </b-icon>
                           </div>
                         </template>
-                        <b-table-column
-                          field="name"
-                          label="Hashtag"
-                          v-slot="props"
-                        >
+                        <b-table-column field="name" label="Hashtag" v-slot="props">
                           <hashtag :value="props.row.displayHashtag"></hashtag>
                         </b-table-column>
-                        <b-table-column
-                          field="tagCount"
-                          label="Tag count"
-                          centered
-                          v-slot="props"
-                        >
+                        <b-table-column field="tagCount" label="Tag count" centered v-slot="props">
                           {{ props.row.tagCount }}
                         </b-table-column>
                       </b-table>
@@ -382,9 +265,7 @@
                   <article class="is-white coming-soon">
                     <h2 class="title is-5">Top owners</h2>
                     <div class="coming-soon-img">
-                      <a href="/auction"
-                        ><img src="~/assets/coming-soon-banner.png"
-                      /></a>
+                      <a href="/auction"><img src="~/assets/coming-soon-banner.png" /></a>
                     </div>
                     <pseudo-owners />
                   </article>

--- a/hashtag-dapp/pages/index.vue
+++ b/hashtag-dapp/pages/index.vue
@@ -7,7 +7,7 @@
           <div class="columns is-tablet is-centered">
             <div class="column is-5 is-12-mobile">
               <article class="tile is-child">
-                <p class="title is-4 has-text-white">Create a HASHTAG token</p>
+                <p class="title is-4 has-text-white">Search HASHTAG tokens</p>
                 <MintingWidget />
               </article>
             </div>


### PR DESCRIPTION
Addresses #241.

> 1. Rename title to "Search HASHTAG tokens"

Done.

> 2. If a HASHTAG token of interest is found, eg. "Bitcoin", make search result clickable and navigate to HASHTAG detail page.

Done.

> 3. If no existing HASHTAG is found, keep existing functionality of pressing enter to mint new token.

👍🏼

> 4. Adjust no existing HASHTAG message/prompt to: "Unique HASHTAG! Press enter to mint it..."

Done.

> 5. Perhaps make call to action design more prominent/visible/compelling.

Would require some refactoring. This is probably not worth doing right now and instead to be done on the React/Next.js refactor.

> 6. As part of this refactor, I suggest we also refactor how the HASHTAG search / graph QL operates. Presently, the first 1000 HASHTAGs are loaded into memory from TheGraph. I think we should refactor or at least explore refactoring so it searches on typing?

Done. I initially thought we needed to add a full text schema update, but it turns out we can just append `_contains` with a `where` search clause like so:

```graphql
query {
  hashtags(where: { hashtagWithoutHash_contains: "bit" }) {
    id
    name
    displayHashtag
    hashtagWithoutHash
    owner
    creator
    publisher
    timestamp
    tagCount
  }
}
```

And this will return the "bitcoin" hashtag (assuming it exists).